### PR TITLE
Fix Gresho Phi

### DIFF
--- a/src/problems/gresho.c
+++ b/src/problems/gresho.c
@@ -27,16 +27,9 @@ float Gresho_Vortex_Density ( const int ipart , const double bias )
 
 float Gresho_Vortex_Phi ( const int ipart )
 {
-
-    if ( P[ipart].Pos[0] > 0 ) {
-        return atan ( P[ipart].Pos[1] / P[ipart].Pos[0] );
-    } else if ( P[ipart].Pos[0] == 0 ) {
-        return P[ipart].Pos[1] / abs ( P[ipart].Pos[1] ) * 0.5 * pi;
-    } else if ( P[ipart].Pos[0] < 0 && P[ipart].Pos[1] >= 0 ) {
-        return atan ( P[ipart].Pos[1] / P[ipart].Pos[0] ) + pi;
-    } else {
-        return atan ( P[ipart].Pos[1] / P[ipart].Pos[0] ) - pi;
-    }
+	double x = P[ipart].Pos[0] - Problem.Boxsize[0] * 0.5;
+	double y = P[ipart].Pos[1] - Problem.Boxsize[1] * 0.5;
+	return atan2 ( y,x );
 }
 
 /* The next step is setting up the velocity profile for the Vortex, following for example Hopkins 2015 or Hu 2014 */


### PR DESCRIPTION
I noticed some inconsistencies in the gresho vortex. Ultimately, they were due to the phi computation.
![Gresho_old](https://user-images.githubusercontent.com/1649109/108506476-23cbb100-72b9-11eb-8d0e-0c07fc1ccbcc.png)
![Gresho_fixed](https://user-images.githubusercontent.com/1649109/108506474-23331a80-72b9-11eb-8e98-21689393deb4.png)


To obtain the figures:
```python
import pynbody
import numpy as np
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
v = pynbody.load('IC_Gresho_fixed')
pynbody.plot.sph.velocity_image(v, width=2, subplot=ax,
                                vmin=0, vmax=1, log=False,
                                quiverkey=False)
ax.set_title('Gresho fixed')
ax.set_xlim(0,1)
ax.set_ylim(0,1)
fig.savefig('Gresho_fixed.png',bbox_inches='tight')


fig, ax = plt.subplots()
v = pynbody.load('IC_Gresho_old')
pynbody.plot.sph.velocity_image(v, width=2, subplot=ax,
                                vmin=0, vmax=1, log=False,
                                quiverkey=False)
ax.set_title('Gresho old')
ax.set_xlim(0,1)
ax.set_ylim(0,1)
fig.savefig('Gresho old.png',bbox_inches='tight')
```
