### PR TITLE
Newer GNU binutils complains about multiple definitions of variables in headers.

### DIFF
--- a/examples/sphere.par
+++ b/examples/sphere.par
@@ -22,8 +22,8 @@ BiasCorrection 0.0
 
 % Problem
 
-Problem_Flag 5
-Problem_Subflag 4
+Problem_Flag 4
+Problem_Subflag 13
 
 PNG_Filename logos/DarthVader.png
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -169,6 +169,5 @@ extern void ( *Velocity_Func_Ptr ) ( const int, float * );
 extern void ( *Magnetic_Field_Func_Ptr ) ( const int, float * );
 extern void ( *PostProcessing_Func_Ptr ) ();
 
-double G; // gravitational constant in code units
 
 #endif

--- a/src/problems/problems.h
+++ b/src/problems/problems.h
@@ -94,6 +94,10 @@ void setup_Boss();
 float Boss_Phi ( double const x, double const y );
 float Boss_Density ( const int ipart , const double bias);
 
+void setup_Truelove1();
+float Truelove1_Phi ( double const x, double const y );
+float Truelove1_Density ( const int ipart , const double bias);
+
 void setup_Sphere();
 float Sphere_Density ( const int ipart , const double bias );
 

--- a/src/problems/problems.h
+++ b/src/problems/problems.h
@@ -94,6 +94,8 @@ void setup_Boss();
 float Boss_Phi ( double const x, double const y );
 float Boss_Density ( const int ipart , const double bias);
 
+void setup_Sphere();
+float Sphere_Density ( const int ipart , const double bias );
 
 void setup_Orszag_Tang_Vortex();
 float Orszag_Tang_Vortex_Density ( const int ipart , const double bias);

--- a/src/problems/sphere.c
+++ b/src/problems/sphere.c
@@ -1,0 +1,36 @@
+#include "../globals.h"
+
+void setup_Sphere()
+{
+    Problem.Boxsize[0] = 1;
+    Problem.Boxsize[1] = 1;
+    Problem.Boxsize[2] = 1;
+
+    sprintf ( Problem.Name, "IC_Sphere" );
+
+    Problem.Rho_Max = 1.0;
+
+    Density_Func_Ptr = &Sphere_Density;
+}
+
+float Sphere_Density ( const int ipart , const double bias )
+{
+    const double rhoIn = 1.0, rhoOut = 0.1;
+
+    const double radius = 0.5;
+
+    double rx,ry,rz;
+
+    rx = P[ipart].Pos[0] - 0.5 * Problem.Boxsize[0];
+    ry = P[ipart].Pos[1] - 0.5 * Problem.Boxsize[1];
+    rz = P[ipart].Pos[2] - 0.5 * Problem.Boxsize[2];
+
+    double r = sqrt(rx*rx + ry*ry + rz*rz);
+
+    if ( r <= radius) {
+        return rhoIn;
+    }
+    else {
+        return rhoOut;
+    }
+}

--- a/src/problems/truelove1.c
+++ b/src/problems/truelove1.c
@@ -1,0 +1,41 @@
+#include "../globals.h"
+
+void setup_Truelove1()
+{
+    Problem.Periodic[0] = Problem.Periodic[1] = Problem.Periodic[2] = false;
+
+    Problem.Boxsize[0] = 0.032; //5e16 cm in parsec
+    Problem.Boxsize[1] = 0.032;
+    Problem.Boxsize[2] = 0.032;
+
+    sprintf ( Problem.Name, "IC_Boss" );
+
+    const double rho =  234177.1; // 10^-16.8 g/cm^3 in solar masses / pc ^3 
+
+    Problem.Rho_Max = rho * 1.1;
+
+    Density_Func_Ptr = &Boss_Density;
+
+}
+
+float Truelove1_Phi ( double const x, double const y )
+{
+
+   return atan2( y , x );
+
+}
+
+/* At first we set up a constant density in the Box */
+float Truelove1_Density ( const int ipart , const double bias )
+{
+    double const x = P[ipart].Pos[0] - Problem.Boxsize[0] * 0.5;
+    double const y = P[ipart].Pos[1] - Problem.Boxsize[1] * 0.5;
+    double const z = P[ipart].Pos[2] - Problem.Boxsize[2] * 0.5;
+
+    double Radius = sqrt ( x*x + y*y + z*z );
+    double R1 = 9.398e-3;
+    const double rho = 234177.1*exp(-pow(Radius/R1, 2));
+
+    return rho * ( 1 + 0.1 * cos ( 2 * Boss_Phi ( x, y ) ) );
+
+}

--- a/src/problems/truelove1.c
+++ b/src/problems/truelove1.c
@@ -8,13 +8,13 @@ void setup_Truelove1()
     Problem.Boxsize[1] = 0.032;
     Problem.Boxsize[2] = 0.032;
 
-    sprintf ( Problem.Name, "IC_Boss" );
+    sprintf ( Problem.Name, "IC_Truelove1" );
 
     const double rho =  234177.1; // 10^-16.8 g/cm^3 in solar masses / pc ^3 
 
     Problem.Rho_Max = rho * 1.1;
 
-    Density_Func_Ptr = &Boss_Density;
+    Density_Func_Ptr = &Truelove1_Density;
 
 }
 
@@ -36,6 +36,6 @@ float Truelove1_Density ( const int ipart , const double bias )
     double R1 = 9.398e-3;
     const double rho = 234177.1*exp(-pow(Radius/R1, 2));
 
-    return rho * ( 1 + 0.1 * cos ( 2 * Boss_Phi ( x, y ) ) );
+    return rho * ( 1 + 0.1 * cos ( 2 * Truelove1_Phi ( x, y ) ) );
 
 }

--- a/src/setup.c
+++ b/src/setup.c
@@ -143,6 +143,9 @@ void setup_problem ( const int Flag, const int Subflag )
         case 12:
             setup_GalaxyCluster();
             break;
+        case 13:
+            setup_Sphere();
+            break;
         default:
             Assert ( false, "Effect %d.%d not implemented", Flag, Subflag );
             break;

--- a/src/setup.c
+++ b/src/setup.c
@@ -146,6 +146,9 @@ void setup_problem ( const int Flag, const int Subflag )
         case 13:
             setup_Sphere();
             break;
+        case 14:
+            setup_Truelove1();
+            break;
         default:
             Assert ( false, "Effect %d.%d not implemented", Flag, Subflag );
             break;

--- a/src/tree.h
+++ b/src/tree.h
@@ -6,7 +6,5 @@ int Find_ngb ( const int ipart, const float hsml, int ngblist[NGBMAX] );
 int Find_ngb_tree ( const int ipart, const float hsml, int ngblist[NGBMAX] );
 int Find_ngb_simple ( const int ipart, const float hsml, int ngblist[NGBMAX] );
 float Guess_hsml ( const size_t ipart, const int DesNumNgb );
-int Ngbcnt ;
-int Ngblist[NGBMAX];
 
 #endif


### PR DESCRIPTION
The variables `G` in `globals.h` and `Ngbcnt` and `Ngblist` in `tree.h` do not need to be defined in the headers as globals.  I'm not exactly sure when this change was introduced to gcc's behaviour, but I can compile the existing version of WVTICs with ld version 2.27, but not with 2.35.2.

I've removed the variables `G`, `Ngbcnt`, and `Ngblist` from the headers `globals.h` and `tree.h`, since they don't need to be defined in multiple locations (`G` is only ever used locally, and `Ngbcnt` and `Ngblist` are never used at all).